### PR TITLE
Check xml node type without namespace

### DIFF
--- a/src/main/java/ZUV/XMLValidator.java
+++ b/src/main/java/ZUV/XMLValidator.java
@@ -161,7 +161,7 @@ public class XMLValidator extends Validator {
 
                 // urn:cen.eu:en16931:2017
                 // urn:cen.eu:en16931:2017:compliant:factur-x.eu:1p0:basic
-                if (root.getNodeName().equalsIgnoreCase("rsm:CrossIndustryInvoice")) { // ZUGFeRD 2.0 or Factur-X
+                if (root.getNodeName().toLowerCase().contains("crossindustryinvoice")) { // ZUGFeRD 2.0 or Factur-X
                     context.setVersion("2");
 
                     isMiniumum = context.getProfile().contains("minimum");


### PR DESCRIPTION
In XML the prefix of the namespace can be chosen freely.

Example:
```
<ns3:CrossIndustryDocument xmlns="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15" xmlns:ns2="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12" xmlns:ns3="urn:ferd:CrossIndustryDocument:invoice:1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="">
```
The validator should not test for a _rsm_ prefix. 